### PR TITLE
CI fragmentation

### DIFF
--- a/.github/workflows/build_and_run.yaml
+++ b/.github/workflows/build_and_run.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Build usvm game server
         working-directory: ./GameServers/usvm/
         run: |
-          ./gradlew build --no-daemon
+          ./gradlew assemble --no-daemon
 
       - name: Build .NET game maps
         working-directory: ./maps/DotNet/Maps

--- a/.github/workflows/build_and_test_usvm.yaml
+++ b/.github/workflows/build_and_test_usvm.yaml
@@ -1,8 +1,12 @@
 name: Build and test USVM submodule
 
-on: [push, pull_request]
-  paths: 
-    - './GameServers/usvm/'
+on: 
+  push
+    paths: 
+      - 'GameServers/usvm/'
+  pull_request
+    paths: 
+      - 'GameServers/usvm/'
 
 jobs:
   build-and-test:

--- a/.github/workflows/build_and_test_usvm.yaml
+++ b/.github/workflows/build_and_test_usvm.yaml
@@ -1,0 +1,26 @@
+name: Build and test USVM submodule
+
+on: [push, pull_request]
+  paths: 
+    - './GameServers/usvm/'
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup Java
+        uses: actions/setup-java@v3.5.0
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+          cache: 'maven'
+
+      - name: Build and test usvm
+        working-directory: ./GameServers/usvm/
+        run: |
+          ./gradlew build --no-daemon

--- a/.github/workflows/build_and_test_usvm.yaml
+++ b/.github/workflows/build_and_test_usvm.yaml
@@ -1,10 +1,10 @@
 name: Build and test USVM submodule
 
 on: 
-  push
+  push:
     paths: 
       - 'GameServers/usvm/'
-  pull_request
+  pull_request:
     paths: 
       - 'GameServers/usvm/'
 

--- a/.github/workflows/build_and_test_usvm.yaml
+++ b/.github/workflows/build_and_test_usvm.yaml
@@ -3,10 +3,10 @@ name: Build and test USVM submodule
 on: 
   push:
     paths: 
-      - 'GameServers/usvm/'
+      - 'GameServers/usvm'
   pull_request:
     paths: 
-      - 'GameServers/usvm/'
+      - 'GameServers/usvm'
 
 jobs:
   build-and-test:


### PR DESCRIPTION
Part of #100 .
- Run USVM tests only for changes in respective submodule.
- Do not run usvm tests  in build-and-launch. Just build USVM and use it for training.