### PR TITLE
Add logging about new map saving

### DIFF
--- a/AIAgent/ml/training/dataset.py
+++ b/AIAgent/ml/training/dataset.py
@@ -419,6 +419,9 @@ class TrainingDataset(Dataset):
         else:
             self.maps_results[map_name] = map_result
             self._save_steps(map_name, filtered_map_steps, map_result)
+            logging.info(
+                f"New map with name {map_name} was saved with result {tuple(map_result)}"
+            )
         del filtered_map_steps
         del map_name
         del map_result


### PR DESCRIPTION
If we add new map to description the first steps sequence obtained by model during validation will be saved to dataset. I think it's better to log it.