### PR TITLE
Fix ruff error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ requires = ["poetry-core"]
 
 [tool.ruff]
 include = ["pyproject.toml", "AIAgent/**/*.py"]
+target-version = "py311"
 
 [tool.ruff.lint]
 select = ["F", "E", "W", "B"]


### PR DESCRIPTION
- Linting is currently not working (it fails with a "syntax error", which is not true for python 3.11)
- [Fix from the discussion](https://github.com/astral-sh/ruff/issues/16417)